### PR TITLE
Fixed the issue: #116651967

### DIFF
--- a/widget/controllers/widget.home.controller.js
+++ b/widget/controllers/widget.home.controller.js
@@ -26,7 +26,7 @@
                 };
 
                 WidgetHome.showDescription = function (description) {
-                    return !((description == '<p>&nbsp;<br></p>') || (description == '<p><br data-mce-bogus="1"></p>'));
+                    return !((description == '<p>&nbsp;<br></p>') || (description == '<p><br data-mce-bogus="1"></p>') || (description == ''));
                 };
                 $rootScope.deviceHeight = window.innerHeight;
                 $rootScope.deviceWidth = window.innerWidth;


### PR DESCRIPTION
This pull request contains the fixes for:  Empty Space still showing for WYSIWYG for new plugins.
